### PR TITLE
Fix fetch_cohort.py to use correct API response attribute

### DIFF
--- a/skills/rwe-analyze/scripts/fetch_cohort.py
+++ b/skills/rwe-analyze/scripts/fetch_cohort.py
@@ -40,7 +40,7 @@ def fetch_cohort_ips(client, description: str, provider: str, label: str) -> lis
             text=description,
             provider=provider
         )
-        patients = cohort_response.patients if hasattr(cohort_response, 'patients') else []
+        patients = cohort_response.patient_ids if hasattr(cohort_response, 'patient_ids') else []
         print(f"Found {len(patients)} patients", file=sys.stderr)
     except Exception as e:
         print(f"Error analyzing cohort: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Fixed `fetch_cohort.py` to use `patient_ids` instead of `patients` when reading the cohort response
- The `analyze_cohort` API returns `patient_ids`, not `patients`, which was causing the script to always return 0 patients

## Test plan
- [x] Tested with "female patients" query - now correctly returns 66 patients (was returning 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)