### PR TITLE
Make PhenoML skills work in Codex and Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,9 @@
 {
   "name": "phenoml-skills",
+  "description": "PhenoML skills for workflow creation and real-world evidence analysis in Codex and Claude Code.",
+  "metadata": {
+    "description": "PhenoML skills for workflow creation and real-world evidence analysis in Codex and Claude Code."
+  },
   "owner": {
     "name": "PhenoML",
     "email": "hello@phenoml.com"
@@ -7,6 +11,8 @@
   "plugins": [
     {
       "name": "phenoml-skills",
+      "description": "Healthcare data workflow and RWE analysis skills for PhenoML.",
+      "version": "0.0.4",
       "source": "./"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "phenoml-skills",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "PhenoML skills for healthcare data processing: workflow creation, condition extraction, patient registration, and real-world evidence analysis",
   "author": {
     "name": "PhenoML",

--- a/README.md
+++ b/README.md
@@ -1,60 +1,91 @@
 # PhenoML Skills
 
-A collection of Claude Code plugins and skills that enable developers to rapidly build and test healthcare data workflows using PhenoML. These interactive skills provide guided, conversational experiences for using PhenoML APIs.
+A shared skills repo for Codex and Claude Code. These skills help developers build, test, and analyze healthcare data workflows using PhenoML APIs.
 
 ## What's Included
 
-### Plugins
-
-- **phenoml-workflow** - Create and execute PhenoML workflows for healthcare data processing
-- **rwe-analyze** - Conduct RWE analysis on FHIR!
-
-### Skills
-
-- **phenoml-workflow** - Interactive skill for:
+- **phenoml-workflow** - Create and execute PhenoML workflows for:
   - Setting up FHIR provider connections
   - Creating workflows
   - Testing workflows with example data
   - Managing and executing healthcare data pipelines
+- **rwe-analyze** - Conduct real-world evidence (RWE) analysis on FHIR data:
+  - Defining patient cohorts from natural language
+  - Generating population-level statistics
+  - Comparing cohorts
+  - Assessing clinical study feasibility
 
 ## Getting Started
 
 ### Prerequisites
 
-- Claude Code CLI installed
-- Python 3.x
+- Codex or Claude Code
+- Python 3.10+
 - PhenoML account credentials
 - FHIR provider credentials (Medplum, Athena, Epic, Cerner, etc.)
-- Best practices: Update your `.claude/settings.json` to ensure sensitive files can't be accessed (example provided in this repo)
-- IMPORTANT: This plugin is designed for development purposes ONLY. Claude Code provides [details](https://code.claude.com/docs/en/third-party-integrations) on how to configure for various enterprise requirements that you may wish to review. 
+- Python packages: `python-dotenv` and `phenoml`
+- For Claude Code, review `.claude/settings.json` and keep sensitive files such as `.env` blocked from reads.
 
-### Installation for use in CLI
+This repo is designed for development use. Review your agent, workspace, and enterprise policies before using it with production systems or regulated data.
 
-1. Start Claude Code in your terminal
+## Install for Codex
+
+Codex discovers skills from `${CODEX_HOME:-$HOME/.codex}/skills`. Copy the shared skill folders there:
+
+```bash
+mkdir -p "${CODEX_HOME:-$HOME/.codex}/skills"
+cp -R skills/phenoml-workflow "${CODEX_HOME:-$HOME/.codex}/skills/"
+cp -R skills/rwe-analyze "${CODEX_HOME:-$HOME/.codex}/skills/"
+```
+
+Restart Codex or start a new session after copying the skills.
+
+## Install for Claude Code CLI
+
+1. Start Claude Code in your terminal:
 ```bash
 claude
 ```
 
-2. Add the marketplace
+2. Add the marketplace:
 ```bash
 /plugin marketplace add PhenoML/phenoml-skills
 ```
 
-3. Install the plugin
+3. Install the plugin:
 ```bash
-/plugin install phenoml-workflow@phenoml-skills
+/plugin install phenoml-skills@phenoml-skills
 ```
 
-### Installation for use in VS Code 
+If you previously installed the old `phenoml-workflow@phenoml-skills` plugin, remove it after installing the current plugin:
+
+```bash
+/plugin uninstall phenoml-workflow@phenoml-skills
+```
+
+## Install for Claude Code in VS Code
 
 1. In the chat input, type `/` to open the command menu.
-   
 2. Select Manage Plugins
-   
 3. Click Marketplaces
-   
 4. Paste the repo URL: `https://github.com/PhenoML/phenoml-skills`
-   
-5. Click Install
-    
+5. Install `phenoml-skills`
 6. PhenoML Skills will now appear in your Plugins list!
+
+## Environment
+
+Create a `.env` file in the project where you are running workflows:
+
+```env
+PHENOML_USERNAME=
+PHENOML_PASSWORD=
+PHENOML_BASE_URL=https://experiment.app.pheno.ml
+
+FHIR_PROVIDER_BASE_URL=
+FHIR_PROVIDER_CLIENT_ID=
+FHIR_PROVIDER_CLIENT_SECRET=
+FHIR_PROVIDER_ID=
+WORKFLOW_ID=
+```
+
+For the shared experiment at `https://experiment.app.pheno.ml`, the workflow and RWE scripts use the preconfigured `experiment-default` FHIR provider when `FHIR_PROVIDER_ID` is not set.

--- a/skills/phenoml-workflow/SKILL.md
+++ b/skills/phenoml-workflow/SKILL.md
@@ -31,7 +31,7 @@ This skill provides a step-by-step interactive experience where the skill **gath
 - If the user gets import errors when running scripts, guide them to install these packages
 
 **Step 1: Check FHIR Provider Setup**
-- First, locate and run `check_env.py` (search for it using glob `**/check_env.py`) to check credentials and detect instance type
+- First, locate and run `scripts/check_env.py` from the directory containing this `SKILL.md` to check credentials and detect instance type. In Claude Code, `${CLAUDE_SKILL_DIR}` can be used when available.
 - **If SHARED EXPERIMENT is detected** (experiment.app.pheno.ml):
   - **Skip FHIR provider setup entirely** - shared experiment uses a pre-configured Medplum sandbox
   - The system automatically uses "experiment-default" as the FHIR_PROVIDER_ID
@@ -79,7 +79,7 @@ This skill provides a step-by-step interactive experience where the skill **gath
 ### Key Principles
 
 1. **Gather information conversationally** - Ask the user questions first to understand their needs
-2. **Find and use the reusable scripts** - First locate the scripts using glob `**/phenoml-workflow/scripts/*.py`, then execute them with appropriate CLI arguments
+2. **Find and use the reusable scripts** - Use the `scripts/*.py` files in the directory containing this `SKILL.md`, then execute them with appropriate CLI arguments
 3. **Always pass --env-file** - Since the scripts may be in a different directory than the user's project, always pass `--env-file /path/to/user/project/.env` to ensure the scripts find the correct .env file (use the user's current working directory)
 4. **Prefer CLI arguments over .env** - For workflow-specific data (name, instructions, test data), pass via CLI args rather than adding to .env
 5. **Use .env for credentials** - Guide users to store credentials (PHENOML_*, MEDPLUM_*, etc.) in .env for security
@@ -91,7 +91,7 @@ This skill provides a step-by-step interactive experience where the skill **gath
 ### Available Scripts
 
 **Important:**
-1. Before running any script, first locate it using glob `**/phenoml-workflow/scripts/*.py` to find the correct path.
+1. Before running any script, first locate the directory containing this `SKILL.md`; the scripts are in its `scripts/` subdirectory. In Claude Code, `${CLAUDE_SKILL_DIR}` can be used when available.
 2. Always pass `--env-file` pointing to the user's project .env file (their current working directory).
 
 #### 0. check_env.py
@@ -239,7 +239,7 @@ python3 /path/to/test_workflow.py \
 When a user asks to "create a workflow to process clinical notes", follow this flow:
 
 1. **Locate the Scripts:**
-   - Use glob `**/phenoml-workflow/scripts/*.py` to find all available scripts
+   - Locate the directory containing this `SKILL.md` and use its `scripts/*.py` files
    - Note their paths for use in subsequent steps
 
 2. **Check Prerequisites and Detect Instance Type:**

--- a/skills/phenoml-workflow/agents/openai.yaml
+++ b/skills/phenoml-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PhenoML Workflow"
+  short_description: "Create and test PhenoML workflows"
+  default_prompt: "Use $phenoml-workflow to create and test a PhenoML healthcare data workflow."

--- a/skills/rwe-analyze/SKILL.md
+++ b/skills/rwe-analyze/SKILL.md
@@ -1,10 +1,15 @@
+---
+name: rwe-analyze
+description: Analyze real-world evidence cohorts using PhenoML APIs and FHIR data. Use when defining patient cohorts from natural language, generating population statistics, comparing cohorts, or assessing clinical study feasibility.
+---
+
 # RWE Cohort Analysis Skill
 
 This skill provides real-world evidence (RWE) analysis using PhenoML APIs. It enables biopharma analysts to define patient cohorts, generate population statistics, compare cohorts, and assess study feasibility.
 
 ## How It Works
 
-A single script (`fetch_cohort.py`) fetches patient data and generates IPS (International Patient Summary) natural language summaries. YOU (Claude) then interpret these summaries to provide whatever analysis the user needs.
+A single script (`fetch_cohort.py`) fetches patient data and generates IPS (International Patient Summary) natural language summaries. The active AI agent then interprets these summaries to provide whatever analysis the user needs.
 
 ## When to Use This Skill
 
@@ -28,8 +33,10 @@ Before using this skill, ensure:
 Always start by checking the environment configuration:
 
 ```bash
-python skills/rwe-analyze/scripts/check_env.py --env-file .env
+python /path/to/skill/scripts/check_env.py --env-file .env
 ```
+
+Resolve `/path/to/skill` as the directory containing this `SKILL.md`. In Claude Code, `${CLAUDE_SKILL_DIR}` can be used when available.
 
 If credentials are missing, guide the user to set up their `.env` file with:
 - PHENOML_USERNAME
@@ -42,14 +49,14 @@ Use the single fetch script for all use cases:
 
 **Single cohort:**
 ```bash
-python skills/rwe-analyze/scripts/fetch_cohort.py \
+python /path/to/skill/scripts/fetch_cohort.py \
   --cohort "<natural language criteria>" \
   --env-file .env
 ```
 
 **Two cohorts for comparison:**
 ```bash
-python skills/rwe-analyze/scripts/fetch_cohort.py \
+python /path/to/skill/scripts/fetch_cohort.py \
   --cohort "<first cohort>" \
   --cohort-2 "<second cohort>" \
   --env-file .env
@@ -57,7 +64,7 @@ python skills/rwe-analyze/scripts/fetch_cohort.py \
 
 ### Step 2: Analyze the IPS Summaries
 
-The script outputs IPS natural language summaries. YOU (Claude) then analyze them based on what the user asked for:
+The script outputs IPS natural language summaries. Analyze them based on what the user asked for:
 
 **Population Analysis:**
 - Total patient count

--- a/skills/rwe-analyze/agents/openai.yaml
+++ b/skills/rwe-analyze/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "RWE Analyze"
+  short_description: "Analyze RWE cohorts with PhenoML"
+  default_prompt: "Use $rwe-analyze to analyze a PhenoML real-world evidence cohort."

--- a/skills/rwe-analyze/scripts/check_env.py
+++ b/skills/rwe-analyze/scripts/check_env.py
@@ -65,14 +65,21 @@ def print_status(results: dict, verbose: bool = False) -> None:
         print("    PHENOML_PASSWORD=your_password")
         print("    PHENOML_BASE_URL=https://experiment.app.pheno.ml")
 
-    print("\nFHIR Provider (for dedicated instances):")
-    for var in results["fhir"]:
-        status = "\u2705" if var["set"] else "\u2b1c"
-        print(f"  {status} {var['name']}")
-
     if instance_type == "shared":
+        print("\nFHIR Provider:")
+        provider_id = next(var for var in results["fhir"] if var["name"] == "FHIR_PROVIDER_ID")
+        if provider_id["set"]:
+            print("  \u2705 FHIR_PROVIDER_ID")
+        else:
+            print("  \u2705 FHIR_PROVIDER_ID (using shared experiment default)")
         print("\n\u2139\ufe0f  FHIR provider credentials not required for shared experiments.")
-    elif not all(var["set"] for var in results["fhir"]):
+    else:
+        print("\nFHIR Provider (for dedicated instances):")
+        for var in results["fhir"]:
+            status = "\u2705" if var["set"] else "\u2b1c"
+            print(f"  {status} {var['name']}")
+
+    if instance_type != "shared" and not all(var["set"] for var in results["fhir"]):
         print("\n\u26a0\ufe0f  FHIR provider not configured.")
         print("  For dedicated instances, configure your FHIR provider.")
 
@@ -114,9 +121,9 @@ def main():
 
     # Check FHIR provider credentials (for dedicated instances)
     fhir_vars = [
-        check_env_var("FHIR_BASE_URL"),
-        check_env_var("FHIR_CLIENT_ID"),
-        check_env_var("FHIR_CLIENT_SECRET"),
+        check_env_var("FHIR_PROVIDER_BASE_URL"),
+        check_env_var("FHIR_PROVIDER_CLIENT_ID"),
+        check_env_var("FHIR_PROVIDER_CLIENT_SECRET"),
         check_env_var("FHIR_PROVIDER_ID")
     ]
 

--- a/skills/rwe-analyze/scripts/fetch_cohort.py
+++ b/skills/rwe-analyze/scripts/fetch_cohort.py
@@ -3,7 +3,7 @@
 Fetch Cohort Script
 
 Fetches patient data and generates IPS summaries for one or two cohorts.
-Claude interprets the summaries to provide analysis, comparison, or feasibility assessment.
+The active AI agent interprets the summaries to provide analysis, comparison, or feasibility assessment.
 
 Usage:
     # Single cohort
@@ -29,6 +29,24 @@ try:
 except ImportError:
     print("Error: phenoml not installed. Run: pip install phenoml")
     sys.exit(1)
+
+
+SHARED_EXPERIMENT_DEFAULT_FHIR_PROVIDER_ID = "experiment-default"
+
+
+def is_shared_experiment(base_url: str | None) -> bool:
+    """Return True when the PhenoML base URL points at the shared experiment."""
+    return bool(base_url and "experiment" in base_url.lower())
+
+
+def resolve_provider(cli_provider: str | None, base_url: str | None) -> tuple[str | None, bool]:
+    """Resolve the FHIR provider ID and whether it came from the shared default."""
+    provider = cli_provider or os.environ.get("FHIR_PROVIDER_ID")
+    if provider:
+        return provider, False
+    if is_shared_experiment(base_url):
+        return SHARED_EXPERIMENT_DEFAULT_FHIR_PROVIDER_ID, True
+    return None, False
 
 
 def fetch_patient_resources(client, patient_id: str, provider: str) -> dict:
@@ -133,24 +151,29 @@ def main():
         print("Error: PHENOML_USERNAME and PHENOML_PASSWORD must be set", file=sys.stderr)
         sys.exit(1)
 
+    base_url = os.environ.get("PHENOML_BASE_URL", "https://experiment.app.pheno.ml")
+
     try:
         client = Client(
             username=os.environ["PHENOML_USERNAME"],
             password=os.environ["PHENOML_PASSWORD"],
-            base_url=os.environ.get("PHENOML_BASE_URL", "https://experiment.app.pheno.ml")
+            base_url=base_url
         )
     except Exception as e:
         print(f"Error initializing client: {e}", file=sys.stderr)
         sys.exit(1)
 
-    # Get provider from CLI arg or environment variable
-    provider = args.provider or os.environ.get("FHIR_PROVIDER_ID")
+    # Get provider from CLI arg, environment variable, or shared experiment default.
+    provider, using_shared_default = resolve_provider(args.provider, base_url)
     if not provider:
         print("Error: FHIR_PROVIDER_ID is required", file=sys.stderr)
-        print("   Set FHIR_PROVIDER_ID in .env, or use --provider", file=sys.stderr)
+        print("   Set FHIR_PROVIDER_ID in .env, use --provider, or use the shared experiment base URL", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Using FHIR provider: {provider}", file=sys.stderr)
+    if using_shared_default:
+        print(f"Using FHIR provider: {provider} (shared experiment default)", file=sys.stderr)
+    else:
+        print(f"Using FHIR provider: {provider}", file=sys.stderr)
 
     # Fetch first cohort
     summaries_1 = fetch_cohort_ips(client, args.cohort, provider, "cohort 1")


### PR DESCRIPTION
Updates the skills repo to use one shared `skills/` tree for Codex and Claude Code, including Codex UI metadata and Claude marketplace metadata/version bump. Adds Codex-compatible frontmatter for `rwe-analyze`, neutralizes agent-specific skill wording, and standardizes script path guidance around the skill directory. Fixes RWE shared-experiment handling so missing `FHIR_PROVIDER_ID` falls back to `experiment-default`, and aligns its env checker with `FHIR_PROVIDER_*` names. Validation: Codex skill validation, `claude plugin validate .`, Python compilation, no-network env/default-provider checks, and `git diff --check` all passed.